### PR TITLE
Support focus locations (with genome browser still at 0.5.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensembl/ensembl-genome-browser",
-  "version": "0.5.2",
+  "version": "0.5.2-focus-loc",
   "description": "Ensembl standalone genome browser",
   "type": "module",
   "main": "dist/bundle-cjs.cjs",

--- a/src/methods/send.ts
+++ b/src/methods/send.ts
@@ -107,7 +107,7 @@ const setFocusGene = (payload: BrowserSetFocusAction['payload'], genomeBrowser: 
 };
 
 const setFocusLocation = (payload: BrowserSetFocusAction['payload'], genomeBrowser: GenomeBrowserType) => {
-  // NOTE: This is a temporary function, until the genome browser is released with proper support of genome locations
+  // NOTE: This is a temporary function, until the genome browser is released with proper support of focus locations
   const { genomeId, focusId, bringIntoView } = payload;
   const locationRegex = /(.+):(\d+)-(\d+)/;
   const [, regionName, start, end] = locationRegex.exec(focusId) ?? [];

--- a/src/methods/send.ts
+++ b/src/methods/send.ts
@@ -4,7 +4,6 @@ import {
   type OutgoingAction,
   type BrowserSetFocusAction
 } from '../types';
-import {  } from '../types';
 
 const send = async (
   genomeBrowser: GenomeBrowserType,

--- a/src/methods/send.ts
+++ b/src/methods/send.ts
@@ -111,7 +111,7 @@ const setFocusLocation = (payload: BrowserSetFocusAction['payload'], genomeBrows
   const { genomeId, focusId, bringIntoView } = payload;
   const locationRegex = /(.+):(\d+)-(\d+)/;
   const [, regionName, start, end] = locationRegex.exec(focusId) ?? [];
-  if (!regionName && start && end) {
+  if (!regionName || !start || !end) {
     return;
   }
   genomeBrowser.set_stick(`${genomeId}:${regionName}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,9 +270,11 @@ export type BrowserSetFocusLocationAction = {
     chromosome: string;
     endBp: number;
     startBp: number;
-    focus: string | null;
     genomeId: string;
-
+    focus?: {
+      id: string;
+      type: string;
+    } | null;
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,7 +257,8 @@ export type TurnOffTranscriptLabelsAction = {
 export type BrowserSetFocusAction = {
   type: OutgoingActionType.SET_FOCUS;
   payload: {
-    focus: string;
+    focusId: string;
+    focusType: string;
     genomeId: string;
     bringIntoView?: boolean;
   };


### PR DESCRIPTION
Add changes to imitate focus locations even before the genome browser can support them.

Related PR: https://github.com/Ensembl/ensembl-client/pull/889